### PR TITLE
Update style guide to double-quotes by default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3930,24 +3930,23 @@ email_with_name = format('%s <%s>', user.name, user.email)
 
 Adopt a consistent string literal quoting style.
 There are two popular styles in the Ruby community, both of which are considered good - single quotes by default and double quotes by default.
-Agworld uses the former, single quoted strings by default.
+Agworld uses the latter, **double** quoted strings by default.
 
 NOTE: The string literals in this guide are using single quotes by default.
 
-==== Single Quote [[consistent-string-literals-single-quote]]
+==== Double Quote [[consistent-string-literals-double-quote]]
 
-Prefer single-quoted strings when you don't need string interpolation or special symbols such as `\t`, `\n`, `'`, etc.
+Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
 
 [source,ruby]
 ----
 # bad
-name = "Bozhidar"
-name = 'De\'Andre'
+name = 'Bozhidar'
+sarcasm = "I \"like\" it."
 
 # good
-name = 'Bozhidar'
-name = "De'Andre"
-name = "#{first_name} #{last_name}"
+name = "Bozhidar"
+sarcasm = 'I "like" it.'
 ----
 
 === No Character Literals [[no-character-literals]]


### PR DESCRIPTION
Please use 👍  or 👎  since this is a style-based preference. Votes close at COB Thursday. 

Companion PR:
https://github.com/agworld/website/pull/10952

Points made in https://github.com/agworld/org-web/pull/15:

> Updating Rubocop to enforce double quote as standard for ruby strings.
> 
> As we are a lot more strict on lint rules for Org-web, I thought we could move from single to double quotes for strings.
> One example of where single quotes doesn't play nicely:
> ```
> irb(main):039:0> x = 1
> irb(main):040:0> "and the necessary swapping here: {x}" \
> irb(main):041:0* 'looks silly side by side'
> "and the necessary swapping here: {x}looks silly side by side"
> ```
> 
> Another good example is even trying to use single quote, ruby by default outputs in double quotes:
> ```
> irb(main):038:0> 'single quotes'
> "single quotes"
> ```
> 
> Other good reason is that is much easier for non-english speakers.
> Usually (like me) they have their keyboard set to multi-language which requires an extra key stroke (space) to put a single quote. Why?
> Because some word have symbols that modifies the stress syllable:
> ```
> Ie. 
> Coração (heart)
> Avó (grandma)
> Você (you)
> ```
> To output those special characters you have to press a symbol (like quote) then vowel!
> 
> Also, usually the standard for JS is always double quotes. (just noticed that Airbnb style enforces single quotes as well)
> So, why do we use single quotes in first place?
> 
> A couple reading about why double quotes:
> https://anti-pattern.com/always-use-double-quoted-strings-in-ruby
> https://www.viget.com/articles/just-use-double-quoted-ruby-strings/

See also:
https://rubystyle.guide/#consistent-string-literals-double-quote